### PR TITLE
gitignoreの修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,6 @@ pickle-email-*.html
 
 # TODO Comment out these rules if you are OK with secrets being uploaded to the repo
 config/initializers/secret_token.rb
-config/secrets.yml
 
 # dotenv
 # TODO Comment out this rule if environment variables can be committed


### PR DESCRIPTION
## やったこと
- リポジトリ管理に含めたいため、`config/secrets.yml`をignoreから外した
- 最初に作ったgitignoreが適用されていなかったため、`git rm --cached -r .`をした
