### PR TITLE
タイムゾーンを東京に設定

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -24,6 +24,7 @@ module AwesomeEvents
     # Set Time.zone default to the specified zone and make Active Record auto-convert to this zone.
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
     # config.time_zone = 'Central Time (US & Canada)'
+    config.time_zone = 'Tokyo'
 
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]


### PR DESCRIPTION
## 概要

p181 タイムゾーンを設定する
## やりたいこと

Railsではデフォルトで時刻がUTCとして扱われてしまうため、日本時間として扱いたい
## 動作確認方法
- [x] `rails console`で`DateTime.current`を実行した時に日本時間で表示されるかどうか
