### PR TITLE
イベント用のモデルEventを作成

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,3 +54,6 @@ group :development do
   gem 'spring'
 end
 
+group :test do
+  gem 'shoulda-matchers'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -44,6 +44,8 @@ group :development, :test do
   gem 'rspec-rails'
 
   gem 'capybara'
+
+  gem 'factory_girl_rails'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,6 +62,11 @@ GEM
     diff-lcs (1.2.5)
     erubis (2.7.0)
     execjs (2.7.0)
+    factory_girl (4.7.0)
+      activesupport (>= 3.0.0)
+    factory_girl_rails (4.7.0)
+      factory_girl (~> 4.7.0)
+      railties (>= 3.0.0)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
     hashie (3.4.4)
@@ -196,6 +201,7 @@ DEPENDENCIES
   byebug
   capybara
   coffee-rails (~> 4.1.0)
+  factory_girl_rails
   jbuilder (~> 2.0)
   jquery-rails
   omniauth

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -160,6 +160,8 @@ GEM
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
+    shoulda-matchers (3.1.1)
+      activesupport (>= 4.0.0)
     slop (3.6.0)
     spring (1.7.1)
     sprockets (3.6.0)
@@ -203,6 +205,7 @@ DEPENDENCIES
   rspec-rails
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
+  shoulda-matchers
   spring
   sqlite3
   turbolinks

--- a/app/assets/javascripts/events.coffee
+++ b/app/assets/javascripts/events.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/events.scss
+++ b/app/assets/stylesheets/events.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the events controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,0 +1,2 @@
+class EventsController < ApplicationController
+end

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -1,0 +1,2 @@
+module EventsHelper
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,0 +1,2 @@
+class Event < ActiveRecord::Base
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,4 +1,6 @@
 class Event < ActiveRecord::Base
+  belongs_to :owner, class_name: 'User'
+
   validates :name, length: { maximum: 50 }, presence: true
   validates :place, length: { maximum: 100 }, presence: true
   validates :content, length: { maximum: 2000 }, presence: true

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,2 +1,3 @@
 class Event < ActiveRecord::Base
+  validates :name, presence: true
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -2,4 +2,5 @@ class Event < ActiveRecord::Base
   validates :name, length: { maximum: 50 }, presence: true
   validates :place, length: { maximum: 100 }, presence: true
   validates :content, length: { maximum: 2000 }, presence: true
+  validates :start_time, presence: true
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -3,6 +3,7 @@ class Event < ActiveRecord::Base
   validates :place, length: { maximum: 100 }, presence: true
   validates :content, length: { maximum: 2000 }, presence: true
   validates :start_time, presence: true
+  validates :end_time, presence: true
   validate :start_time_should_be_before_end_time
 
   private

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,3 +1,3 @@
 class Event < ActiveRecord::Base
-  validates :name, presence: true
+  validates :name, length: { maximum: 50 }, presence: true
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,4 +1,5 @@
 class Event < ActiveRecord::Base
   validates :name, length: { maximum: 50 }, presence: true
   validates :place, length: { maximum: 100 }, presence: true
+  validates :content, length: { maximum: 2000 }, presence: true
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,3 +1,4 @@
 class Event < ActiveRecord::Base
   validates :name, length: { maximum: 50 }, presence: true
+  validates :place, length: { maximum: 100 }, presence: true
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -3,4 +3,15 @@ class Event < ActiveRecord::Base
   validates :place, length: { maximum: 100 }, presence: true
   validates :content, length: { maximum: 2000 }, presence: true
   validates :start_time, presence: true
+  validate :start_time_should_be_before_end_time
+
+  private
+
+  def start_time_should_be_before_end_time
+    return unless start_time && end_time
+
+    if start_time >= end_time
+      errors.add(:start_time, 'は終了時間よりも前に設定してください')
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,6 @@
 class User < ActiveRecord::Base
+  has_many :created_events, class_name: 'Event', foreign_key: :owner_id
+
   def self.find_or_create_from_auth_hash(auth_hash)
     provider = auth_hash[:provider]
     uid = auth_hash[:uid]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 Rails.application.routes.draw do
+  resources :events
   root to: 'welcome#index'
   get '/auth/:provider/callback' => 'sessions#create'
   get '/logout' => 'sessions#destroy', as: :logout

--- a/db/migrate/20160526054404_create_events.rb
+++ b/db/migrate/20160526054404_create_events.rb
@@ -1,12 +1,12 @@
 class CreateEvents < ActiveRecord::Migration
   def change
     create_table :events do |t|
-      t.integer :owner_id
-      t.string :name
-      t.string :place
-      t.datetime :start_time
-      t.datetime :end_time
-      t.text :content
+      t.integer  :owner_id
+      t.string   :name,       null: false
+      t.string   :place,      null: false
+      t.datetime :start_time, null: false
+      t.datetime :end_time,   null: false
+      t.text     :content,    null: false
 
       t.timestamps null: false
     end

--- a/db/migrate/20160526054404_create_events.rb
+++ b/db/migrate/20160526054404_create_events.rb
@@ -10,5 +10,7 @@ class CreateEvents < ActiveRecord::Migration
 
       t.timestamps null: false
     end
+
+    add_index :events, :owner_id
   end
 end

--- a/db/migrate/20160526054404_create_events.rb
+++ b/db/migrate/20160526054404_create_events.rb
@@ -1,0 +1,14 @@
+class CreateEvents < ActiveRecord::Migration
+  def change
+    create_table :events do |t|
+      t.integer :owner_id
+      t.string :name
+      t.string :place
+      t.datetime :start_time
+      t.datetime :end_time
+      t.text :content
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160524044406) do
+ActiveRecord::Schema.define(version: 20160526054404) do
+
+  create_table "events", force: :cascade do |t|
+    t.integer  "owner_id"
+    t.string   "name",       null: false
+    t.string   "place",      null: false
+    t.datetime "start_time", null: false
+    t.datetime "end_time",   null: false
+    t.text     "content",    null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_index "events", ["owner_id"], name: "index_events_on_owner_id"
 
   create_table "users", force: :cascade do |t|
     t.string   "provider",   null: false

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe EventsController, type: :controller do
+
+end

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :event do
+    
+  end
+end

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -1,5 +1,10 @@
 FactoryGirl.define do
   factory :event do
-    
+    owner
+    sequence(:name) { |i| "イベント名#{i}" }
+    sequence(:place) { |i| "イベント開催場所#{i}" }
+    sequence(:content) { |i| "イベント本文#{i}" }
+    start_time { rand(1..30).days.from_now }
+    end_time { start_time + rand(1..30).hours }
   end
 end

--- a/spec/factories/events.rb
+++ b/spec/factories/events.rb
@@ -6,5 +6,9 @@ FactoryGirl.define do
     sequence(:content) { |i| "イベント本文#{i}" }
     start_time { rand(1..30).days.from_now }
     end_time { start_time + rand(1..30).hours }
+
+    trait :has_invalid_end_time do
+      end_time { start_time - rand(1..30).hours }
+    end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :user do
+    
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,5 +1,8 @@
 FactoryGirl.define do
-  factory :user do
-    
+  factory :user, aliases: [:owner] do
+    provider 'twitter'
+    sequence(:uid) { |i| "uid#{i}" }
+    sequence(:nickname) { |i| "nickname#{i}" }
+    sequence(:image_url) { |i| "http://example.com/image#{i}.jpg" }
   end
 end

--- a/spec/helpers/events_helper_spec.rb
+++ b/spec/helpers/events_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the EventsHelper. For example:
+#
+# describe EventsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe EventsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Event, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -39,4 +39,8 @@ RSpec.describe Event, type: :model do
       end
     end
   end
+
+  describe '#end_time' do
+    it { should validate_presence_of(:end_time) }
+  end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -3,8 +3,9 @@ require 'rails_helper'
 RSpec.describe Event, type: :model do
   describe '#name' do
     context '空白の時' do
+      let(:event) { Event.new(name: '') }
+
       it 'validでないこと' do
-        event = Event.new(name: '')
         event.valid?
         expect(event.errors[:name]).to be_present
       end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -2,6 +2,15 @@ require 'rails_helper'
 
 RSpec.describe Event, type: :model do
   describe '#name' do
+    context 'nilの時' do
+      let(:event) { Event.new(name: nil) }
+
+      it 'validでないこと' do
+        event.valid?
+        expect(event.errors[:name]).to be_present
+      end
+    end
+
     context '空白の時' do
       let(:event) { Event.new(name: '') }
 

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -19,5 +19,23 @@ RSpec.describe Event, type: :model do
         expect(event.errors[:name]).to be_present
       end
     end
+
+    context '"Rails勉強会"の時' do
+      let(:event) { Event.new(name: 'Rails勉強会') }
+
+      it 'validであること' do
+        event.valid?
+        expect(event.errors[:name]).to be_blank
+      end
+    end
+
+    context '50文字の時' do
+      let(:event) { Event.new(name: 'a' * 50) }
+
+      it 'validであること' do
+        event.valid?
+        expect(event.errors[:name]).to be_blank
+      end
+    end
   end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -10,4 +10,9 @@ RSpec.describe Event, type: :model do
     it { should validate_presence_of(:place) }
     it { should validate_length_of(:place).is_at_most(100) }
   end
+
+  describe '#content' do
+    it { should validate_presence_of(:content) }
+    it { should validate_length_of(:content).is_at_most(2000) }
+  end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -2,49 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Event, type: :model do
   describe '#name' do
-    context 'nilの時' do
-      let(:event) { Event.new(name: nil) }
-
-      it 'validでないこと' do
-        event.valid?
-        expect(event.errors[:name]).to be_present
-      end
-    end
-
-    context '空白の時' do
-      let(:event) { Event.new(name: '') }
-
-      it 'validでないこと' do
-        event.valid?
-        expect(event.errors[:name]).to be_present
-      end
-    end
-
-    context '"Rails勉強会"の時' do
-      let(:event) { Event.new(name: 'Rails勉強会') }
-
-      it 'validであること' do
-        event.valid?
-        expect(event.errors[:name]).to be_blank
-      end
-    end
-
-    context '50文字の時' do
-      let(:event) { Event.new(name: 'a' * 50) }
-
-      it 'validであること' do
-        event.valid?
-        expect(event.errors[:name]).to be_blank
-      end
-    end
-
-    context '51文字の時' do
-      let(:event) { Event.new(name: 'a' * 51) }
-
-      it 'validでないこと' do
-        event.valid?
-        expect(event.errors[:name]).to be_present
-      end
-    end
+    it { should validate_presence_of(:name) }
+    it { should validate_length_of(:name).is_at_most(50) }
   end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -37,5 +37,14 @@ RSpec.describe Event, type: :model do
         expect(event.errors[:name]).to be_blank
       end
     end
+
+    context '51文字の時' do
+      let(:event) { Event.new(name: 'a' * 51) }
+
+      it 'validでないこと' do
+        event.valid?
+        expect(event.errors[:name]).to be_present
+      end
+    end
   end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -17,6 +17,26 @@ RSpec.describe Event, type: :model do
   end
 
   describe '#start_time' do
+    let(:start_time) { DateTime.new(2015, 1, 1, 0, 0, 0) }
+
     it { should validate_presence_of(:start_time) }
+
+    context 'start_timeがend_timeより前の時間の時' do
+      let(:event) { Event.new(start_time: start_time, end_time: start_time.next_year) }
+
+      it 'validであること' do
+        event.valid?
+        expect(event.errors[:start_time]).to be_blank
+      end
+    end
+
+    context 'start_timeがend_timeより後の時間の時' do
+      let(:event) { Event.new(start_time: start_time, end_time: start_time - 1.year) }
+
+      it 'validでないこと' do
+        event.valid?
+        expect(event.errors[:start_time]).to be_present
+      end
+    end
   end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -1,5 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe Event, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe '#name' do
+    context '空白の時' do
+      it 'validでないこと' do
+        event = Event.new(name: '')
+        event.valid?
+        expect(event.errors[:name]).to be_present
+      end
+    end
+  end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -17,12 +17,10 @@ RSpec.describe Event, type: :model do
   end
 
   describe '#start_time' do
-    let(:start_time) { DateTime.new(2015, 1, 1, 0, 0, 0) }
-
     it { should validate_presence_of(:start_time) }
 
     context 'start_timeがend_timeより前の時間の時' do
-      let(:event) { Event.new(start_time: start_time, end_time: start_time.next_year) }
+      let(:event) { build(:event) }
 
       it 'validであること' do
         event.valid?
@@ -31,7 +29,7 @@ RSpec.describe Event, type: :model do
     end
 
     context 'start_timeがend_timeより後の時間の時' do
-      let(:event) { Event.new(start_time: start_time, end_time: start_time - 1.year) }
+      let(:event) { build(:event, :has_invalid_end_time) }
 
       it 'validでないこと' do
         event.valid?

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -5,4 +5,9 @@ RSpec.describe Event, type: :model do
     it { should validate_presence_of(:name) }
     it { should validate_length_of(:name).is_at_most(50) }
   end
+
+  describe '#place' do
+    it { should validate_presence_of(:place) }
+    it { should validate_length_of(:place).is_at_most(100) }
+  end
 end

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -15,4 +15,8 @@ RSpec.describe Event, type: :model do
     it { should validate_presence_of(:content) }
     it { should validate_length_of(:content).is_at_most(2000) }
   end
+
+  describe '#start_time' do
+    it { should validate_presence_of(:start_time) }
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -69,6 +69,8 @@ RSpec.configure do |config|
       }
     })
   end
+
+  config.include FactoryGirl::Syntax::Methods
 end
 
 Shoulda::Matchers.configure do |config|

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -70,3 +70,10 @@ RSpec.configure do |config|
     })
   end
 end
+
+Shoulda::Matchers.configure do |config|
+  config.integrate do |with|
+    with.test_framework :rspec
+    with.library :rails
+  end
+end


### PR DESCRIPTION
#9 の差分が大きくなってきたのでPR分けました。
## 概要

p182 イベント用のモデルを作成する
## やりたいこと
- [x] 以下の情報を持つイベント用のモデルを作成する
  - イベント名
  - 開催場所
  - 開始時間
  - 終了時間
  - 詳細情報
  - 作成者
- 各属性に対して以下のバリデーションを設定したい
  - [x] イベント名、開催場所、開始時間、終了時間、詳細情報の記入は必須
  - [x] イベント名は50文字以下
  - [x] 開催場所は100文字以下
  - [x] 詳細情報は2000文字以下
  - [x] 開始時間は終了時間よりも前の時間である
## 追加したgem
- shoulda-matchers
- factory_girl_rails
