### PR TITLE
イベントの登録機能を追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -10,4 +10,9 @@ class ApplicationController < ActionController::Base
   def logged_in?
     !!session[:user_id]
   end
+
+  def authenticate
+    return if logged_in?
+    redirect_to root_path, alert: 'ログインしてください'
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,9 +3,14 @@ class ApplicationController < ActionController::Base
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
 
-  helper_method :logged_in?
+  helper_method :current_user, :logged_in?
 
   private
+
+  def current_user
+    return unless session[:user_id]
+    @current_user ||= User.find(session[:user_id])
+  end
 
   def logged_in?
     !!session[:user_id]

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -2,6 +2,7 @@ class EventsController < ApplicationController
   before_action :authenticate
 
   def new
+    @event = Event.new
     head :ok
   end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -9,6 +9,8 @@ class EventsController < ApplicationController
     @event = current_user.created_events.create(event_params)
     if @event.save
       redirect_to @event, notice: '作成しました'
+    else
+      render :new
     end
   end
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -4,4 +4,15 @@ class EventsController < ApplicationController
   def new
     @event = current_user.created_events.build
   end
+
+  def create
+    @event = current_user.created_events.create(event_params)
+    head :created
+  end
+
+  private
+
+  def event_params
+    params.require(:event).permit(:name, :place, :content, :start_time, :end_time)
+  end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,4 +1,6 @@
 class EventsController < ApplicationController
+  before_action :authenticate
+
   def new
     head :ok
   end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -2,7 +2,7 @@ class EventsController < ApplicationController
   before_action :authenticate
 
   def new
-    @event = Event.new
+    @event = User.find(session[:user_id]).created_events.build
     head :ok
   end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -2,7 +2,7 @@ class EventsController < ApplicationController
   before_action :authenticate
 
   def new
-    @event = User.find(session[:user_id]).created_events.build
+    @event = current_user.created_events.build
     head :ok
   end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -7,7 +7,9 @@ class EventsController < ApplicationController
 
   def create
     @event = current_user.created_events.create(event_params)
-    head :created
+    if @event.save
+      redirect_to @event, notice: '作成しました'
+    end
   end
 
   private

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -3,6 +3,5 @@ class EventsController < ApplicationController
 
   def new
     @event = current_user.created_events.build
-    head :ok
   end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -1,2 +1,5 @@
 class EventsController < ApplicationController
+  def new
+    head :ok
+  end
 end

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -5,6 +5,16 @@
 </div>
 
 <%= form_for(@event, class: 'form-horizontal', role: 'form') do |f| %>
+  <% if @event.errors.any? %>
+    <div class="alert alert-danger">
+      <ul>
+        <% @event.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
   <div class="form-group">
     <%= f.label :name %>
     <%= f.text_field :name, class: 'form-control' %>

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -1,0 +1,38 @@
+<% now = Time.zone.now %>
+
+<div class="page-header">
+  <h1>イベント作成</h1>
+</div>
+
+<%= form_for(@event, class: 'form-horizontal', role: 'form') do |f| %>
+  <div class="form-group">
+    <%= f.label :name %>
+    <%= f.text_field :name, class: 'form-control' %>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :place %>
+    <%= f.text_field :place, class: 'form-control' %>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :start_time %>
+    <div>
+      <%= f.datetime_select :start_time, start_year: now.year, end_year: now.year + 1 %>
+    </div>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :end_time %>
+    <div>
+      <%= f.datetime_select :end_time, start_year: now.year, end_year: now.year + 1 %>
+    </div>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :content %>
+    <%= f.text_area :content, class: 'form-control', row: 10 %>
+  </div>
+
+  <%= f.submit '作成', class: 'btn btn-default', data: { disable_with: '作成中…' } %>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -22,6 +22,7 @@
         </div>
         <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
           <ul class="nav navbar-nav navbar-right">
+            <li><%= link_to 'イベントを作る', new_event_path %></li>
             <% if logged_in? %>
               <li><%= link_to 'ログアウト', logout_path %></li>
             <% else %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -39,6 +39,11 @@
           <%= flash[:notice] %>
         </div>
       <% end %>
+      <% if flash[:alert] %>
+        <div class="alert alert-danger">
+          <%= flash[:alert] %>
+        </div>
+      <% end %>
 
       <%= yield %>
     </div>

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -18,6 +18,10 @@ RSpec.describe EventsController, type: :controller do
         expect(assigns(:event).owner).to be_a(user.class)
         expect(assigns(:event)).to be_a_new(Event)
       end
+
+      it 'newテンプレートをrenderしていること' do
+        expect(response).to render_template(:new)
+      end
     end
 
     context '未ログインユーザーがアクセスした時' do

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -13,6 +13,10 @@ RSpec.describe EventsController, type: :controller do
       it 'ステータスコードとして200が返ること' do
         expect(response).to have_http_status(200)
       end
+
+      it '@eventに新規Eventオブジェクトが格納されていること' do
+        expect(assigns(:event)).to be_a_new(Event)
+      end
     end
 
     context '未ログインユーザーがアクセスした時' do

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -3,8 +3,8 @@ require 'rails_helper'
 RSpec.describe EventsController, type: :controller do
   describe 'GET #new' do
     context 'ログインユーザーがアクセスした時' do
+      let(:user) { user = create(:user) }
       before do
-        user = create(:user)
         session[:user_id] = user.id
 
         get :new
@@ -14,7 +14,8 @@ RSpec.describe EventsController, type: :controller do
         expect(response).to have_http_status(200)
       end
 
-      it '@eventに新規Eventオブジェクトが格納されていること' do
+      it '@eventにログインユーザーに紐付いた新規Eventオブジェクトが格納されていること' do
+        expect(assigns(:event).owner).to be_a(user.class)
         expect(assigns(:event)).to be_a_new(Event)
       end
     end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -34,4 +34,52 @@ RSpec.describe EventsController, type: :controller do
       end
     end
   end
+
+  describe 'POST #create' do
+    context 'ログインユーザーがアクセスした時' do
+      let(:user) { create(:user) }
+      let(:request_params) do
+        {
+          event: {
+            name: 'event name',
+            place: 'event place',
+            content: 'event content',
+            start_time: DateTime.new(2016, 1, 1, 0, 0, 0),
+            end_time: DateTime.new(2016, 1, 2, 0, 0, 0)
+          }
+        }
+      end
+
+      before do
+        session[:user_id] = user.id
+
+        post :create, request_params
+      end
+
+      it '@eventにログインユーザーに紐付いたEventオブジェクトが格納されていること' do
+        expect(assigns(:event).owner).to be_a(user.class)
+      end
+
+      it '@eventにリクエストパラメータとして送信した値が格納されていること' do
+        expect(assigns(:event).name).to eq request_params[:event][:name]
+        expect(assigns(:event).place).to eq request_params[:event][:place]
+        expect(assigns(:event).content).to eq request_params[:event][:content]
+        expect(assigns(:event).start_time).to eq request_params[:event][:start_time]
+        expect(assigns(:event).end_time).to eq request_params[:event][:end_time]
+      end
+
+      it 'イベントを新規作成できていること' do
+        expect(Event.last).to eq assigns(:event)
+      end
+
+    context '未ログインユーザーがアクセスした時' do
+      before do
+        post :create
+      end
+
+      it 'トップページにリダイレクトさせること' do
+        expect(response).to redirect_to(root_path)
+      end
+    end
+  end
 end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -1,5 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe EventsController, type: :controller do
+  describe 'GET #new' do
+    before do
+      get :new
+    end
 
+    it 'ステータスコードとして200が返ること' do
+      expect(response).to have_http_status(200)
+    end
+  end
 end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -72,6 +72,11 @@ RSpec.describe EventsController, type: :controller do
         expect(Event.last).to eq assigns(:event)
       end
 
+      it '作成したイベントの詳細ページにリダイレクトされていること' do
+        expect(response).to redirect_to(event_path(assigns(:event)))
+      end
+    end
+
     context '未ログインユーザーがアクセスした時' do
       before do
         post :create

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -2,12 +2,27 @@ require 'rails_helper'
 
 RSpec.describe EventsController, type: :controller do
   describe 'GET #new' do
-    before do
-      get :new
+    context 'ログインユーザーがアクセスした時' do
+      before do
+        user = create(:user)
+        session[:user_id] = user.id
+
+        get :new
+      end
+
+      it 'ステータスコードとして200が返ること' do
+        expect(response).to have_http_status(200)
+      end
     end
 
-    it 'ステータスコードとして200が返ること' do
-      expect(response).to have_http_status(200)
+    context '未ログインユーザーがアクセスした時' do
+      before do
+        get :new
+      end
+
+      it 'トップページにリダイレクトさせること' do
+        expect(response).to redirect_to(root_path)
+      end
     end
   end
 end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe EventsController, type: :controller do
   describe 'GET #new' do
     context 'ログインユーザーがアクセスした時' do
-      let(:user) { user = create(:user) }
+      let(:user) { create(:user) }
       before do
         session[:user_id] = user.id
 

--- a/spec/views/events/new.html.erb_spec.rb
+++ b/spec/views/events/new.html.erb_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "events/new", type: :view do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/views/events/new.html.erb_spec.rb
+++ b/spec/views/events/new.html.erb_spec.rb
@@ -10,5 +10,19 @@ RSpec.describe "events/new", type: :view do
     it '「イベント作成」という見出しが含まれたトップページが表示されること' do
       expect(rendered).to match /イベント作成/
     end
+
+    context 'かつ入力した内容にエラーがあった時' do
+      let(:event) { build(:event, :has_invalid_end_time) }
+
+      before do
+        event.valid?
+        assign(:event, event)
+        render
+      end
+
+      it 'エラーメッセージが表示されていること' do
+        expect(rendered).to match /#{event.errors.full_messages.first}/
+      end
+    end
   end
 end

--- a/spec/views/events/new.html.erb_spec.rb
+++ b/spec/views/events/new.html.erb_spec.rb
@@ -1,5 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe "events/new", type: :view do
-  pending "add some examples to (or delete) #{__FILE__}"
+  context 'ログインユーザーがアクセスした時' do
+    before do
+      assign(:event, create(:event))
+      render
+    end
+
+    it '「イベント作成」という見出しが含まれたトップページが表示されること' do
+      expect(rendered).to match /イベント作成/
+    end
+  end
 end


### PR DESCRIPTION
## 概要

p185 ログイン状態を管理する処理を作る
p250 fixture replacement
## やりたいこと
- [x] ヘッダーに「イベントを作る」リンクを作成する
- [x] ログイン状態で「イベントを作る」をクリックすると、イベント登録フォームに遷移する
- [x] 未ログイン状態で「イベントを作る」をクリックすると、トップページにリダイレクトする
- [x] イベント登録フォームで間違った入力をするとエラーメッセージが表示される
- [x] イベント登録フォームで正しく入力をするとイベントが登録される
## 動作確認
- [x] イベント登録フォームから正しい情報を入力した時にDB側に作成したイベントが保存されているか
- [x] 未ログイン状態で`/events/new`にアクセスした時にトップページにリダイレクトするか
- [x] イベント登録フォームで誤った情報を入力した時にエラーメッセージが表示されるか
- [x] イベント作成後にイベント詳細ページにリダイレクトされるか
