### PR TITLE
[WIP] イベントの編集機能を追加

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -22,6 +22,14 @@ class EventsController < ApplicationController
     @event = current_user.created_events.find(params[:id])
   end
 
+  def update
+    @event = current_user.created_events.find(params[:id])
+
+    if @event.update(event_params)
+      head :ok
+    end
+  end
+
   private
 
   def event_params

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -26,7 +26,7 @@ class EventsController < ApplicationController
     @event = current_user.created_events.find(params[:id])
 
     if @event.update(event_params)
-      head :ok
+      redirect_to @event, notice: '更新しました'
     end
   end
 

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -19,7 +19,7 @@ class EventsController < ApplicationController
   end
 
   def edit
-    @event = Event.find(params[:id])
+    @event = current_user.created_events.find(params[:id])
   end
 
   private

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -18,6 +18,10 @@ class EventsController < ApplicationController
     end
   end
 
+  def edit
+    head :ok
+  end
+
   private
 
   def event_params

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -19,7 +19,7 @@ class EventsController < ApplicationController
   end
 
   def edit
-    head :ok
+    @event = Event.find(params[:id])
   end
 
   private

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -8,6 +8,11 @@ class Event < ActiveRecord::Base
   validates :end_time, presence: true
   validate :start_time_should_be_before_end_time
 
+  def created_by?(user)
+    return false unless user
+    owner_id == user.id
+  end
+
   private
 
   def start_time_should_be_before_end_time

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -1,0 +1,48 @@
+<% now = Time.zone.now %>
+
+<div class="page-header">
+  <h1>イベント情報編集</h1>
+</div>
+
+<%= form_for(@event, class: 'form-horizontal', role: 'form') do |f| %>
+  <% if @event.errors.any? %>
+    <div class="alert alert-danger">
+      <ul>
+        <% @event.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="form-group">
+    <%= f.label :name %>
+    <%= f.text_field :name, class: 'form-control' %>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :place %>
+    <%= f.text_field :place, class: 'form-control' %>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :start_time %>
+    <div>
+      <%= f.datetime_select :start_time, start_year: now.year, end_year: now.year + 1 %>
+    </div>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :end_time %>
+    <div>
+      <%= f.datetime_select :end_time, start_year: now.year, end_year: now.year + 1 %>
+    </div>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :content %>
+    <%= f.text_area :content, class: 'form-control', row: 10 %>
+  </div>
+
+  <%= f.submit '更新', class: 'btn btn-default', data: { disable_with: '更新中…' } %>
+<% end %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -42,3 +42,7 @@
     <%= @event.content %>
   </div>
 </div>
+
+<% if @event.created_by?(current_user) %>
+  <%= link_to 'イベントを編集する', edit_event_path(@event), class: 'btn btn-info btn-lg btn-block' %>
+<% end %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -4,45 +4,51 @@
   </h1>
 </div>
 
-<div class="panel panel-default">
-  <div class="panel-heading">
-    主催者
+<div class="row">
+  <div class="col-md-8">
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        主催者
+      </div>
+      <div class="panel-body">
+        <%= link_to "https://twitter.com/#{@event.owner.nickname}" do %>
+          <%= image_tag @event.owner.image_url %>
+          <%= "@#{@event.owner.nickname}" %>
+        <% end %>
+      </div>
+    </div>
+
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        開催時間
+      </div>
+      <div class="panel-body">
+        <%= @event.start_time.strftime('%Y/%m/%d %H:%M') %> - <%= @event.end_time.strftime('%Y/%m/%d %H:%M') %>
+      </div>
+    </div>
+
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        開催場所
+      </div>
+      <div class="panel-body">
+        <%= @event.place %>
+      </div>
+    </div>
+
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        イベント内容
+      </div>
+      <div class="panel-body">
+        <%= @event.content %>
+      </div>
+    </div>
   </div>
-  <div class="panel-body">
-    <%= link_to "https://twitter.com/#{@event.owner.nickname}" do %>
-      <%= image_tag @event.owner.image_url %>
-      <%= "@#{@event.owner.nickname}" %>
+
+  <div class="col-md-4">
+    <% if @event.created_by?(current_user) %>
+      <%= link_to 'イベントを編集する', edit_event_path(@event), class: 'btn btn-info btn-lg btn-block' %>
     <% end %>
   </div>
 </div>
-
-<div class="panel panel-default">
-  <div class="panel-heading">
-    開催時間
-  </div>
-  <div class="panel-body">
-    <%= @event.start_time.strftime('%Y/%m/%d %H:%M') %> - <%= @event.end_time.strftime('%Y/%m/%d %H:%M') %>
-  </div>
-</div>
-
-<div class="panel panel-default">
-  <div class="panel-heading">
-    開催場所
-  </div>
-  <div class="panel-body">
-    <%= @event.place %>
-  </div>
-</div>
-
-<div class="panel panel-default">
-  <div class="panel-heading">
-    イベント内容
-  </div>
-  <div class="panel-body">
-    <%= @event.content %>
-  </div>
-</div>
-
-<% if @event.created_by?(current_user) %>
-  <%= link_to 'イベントを編集する', edit_event_path(@event), class: 'btn btn-info btn-lg btn-block' %>
-<% end %>

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -140,7 +140,16 @@ RSpec.describe EventsController, type: :controller do
   describe 'GET #edit' do
     context 'ログインユーザーがアクセスした時' do
       context 'かつ指定したidのイベント情報が登録されている時' do
+        let(:event) { create(:event) }
+        let(:user) { create(:user) }
+
+        before do
+          session[:user_id] = user.id
+          get :edit, id: event.id
+        end
+
         it '200が返されること' do
+          expect(response).to have_http_status(200)
         end
 
         it '指定したidのイベント情報が返されること'

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -139,12 +139,16 @@ RSpec.describe EventsController, type: :controller do
 
   describe 'GET #edit' do
     context 'ログインユーザーがアクセスした時' do
+      let(:user) { create(:user) }
+
+      before do
+        session[:user_id] = user.id
+      end
+
       context 'かつ指定したidのイベント情報が登録されている時' do
         let(:event) { create(:event) }
-        let(:user) { create(:user) }
 
         before do
-          session[:user_id] = user.id
           get :edit, id: event.id
         end
 

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -194,4 +194,48 @@ RSpec.describe EventsController, type: :controller do
       end
     end
   end
+
+  describe 'PATCH #update' do
+    context 'ログインユーザーがアクセスした時' do
+      let(:user) { create(:user) }
+
+      before do
+        session[:user_id] = user.id
+      end
+
+      context 'かつ指定したidのイベント情報が登録されている時' do
+        context 'かつログインユーザーが作成したイベントである時' do
+          let(:event) { create(:event, owner: user) }
+
+          context 'かつ正しいイベント情報をパラメータに含めた時' do
+            let(:valid_request_params) do
+              {
+                id: event.id,
+                event: {
+                  name: 'updated event name',
+                  place: 'updated event place',
+                  content: 'updated event content',
+                  start_time: DateTime.new(2017, 1, 1, 0, 0, 0),
+                  end_time: DateTime.new(2017, 1, 2, 0, 0, 0)
+                }
+              }
+            end
+
+            before do
+              patch :update, valid_request_params
+            end
+
+            it 'urlパラメータで指定したidのイベント情報が更新されていること' do
+              updated_event = Event.find(event.id)
+              expect(updated_event.name).to eq valid_request_params[:event][:name]
+              expect(updated_event.place).to eq valid_request_params[:event][:place]
+              expect(updated_event.content).to eq valid_request_params[:event][:content]
+              expect(updated_event.start_time).to eq valid_request_params[:event][:start_time]
+              expect(updated_event.end_time).to eq valid_request_params[:event][:end_time]
+            end
+          end
+        end
+      end
+    end
+  end
 end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -166,7 +166,9 @@ RSpec.describe EventsController, type: :controller do
       end
 
       context 'かつ指定したidのイベント情報が登録されていない時' do
-        it '404が返されること'
+        it 'ActiveRecord::RecordNotFoundがraiseされること' do
+          expect { get :edit, id: 0 }.to raise_error(ActiveRecord::RecordNotFound)
+        end
       end
     end
 

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -152,9 +152,13 @@ RSpec.describe EventsController, type: :controller do
           expect(response).to have_http_status(200)
         end
 
-        it '指定したidのイベント情報が返されること'
+        it '指定したidのイベント情報が返されること' do
+          expect(assigns(:event).id).to eq event.id
+        end
 
-        it 'editテンプレートをrenderしていること'
+        it 'editテンプレートをrenderしていること' do
+          expect(response).to render_template :edit
+        end
       end
 
       context 'かつ指定したidのイベント情報が登録されていない時' do

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -136,4 +136,25 @@ RSpec.describe EventsController, type: :controller do
       end
     end
   end
+
+  describe 'GET #edit' do
+    context 'ログインユーザーがアクセスした時' do
+      context 'かつ指定したidのイベント情報が登録されている時' do
+        it '200が返されること' do
+        end
+
+        it '指定したidのイベント情報が返されること'
+
+        it 'editテンプレートをrenderしていること'
+      end
+
+      context 'かつ指定したidのイベント情報が登録されていない時' do
+        it '404が返されること'
+      end
+    end
+
+    context '未ログインユーザーがアクセスした時' do
+      it 'トップページにリダイレクトさせること'
+    end
+  end
 end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -173,7 +173,15 @@ RSpec.describe EventsController, type: :controller do
     end
 
     context '未ログインユーザーがアクセスした時' do
-      it 'トップページにリダイレクトさせること'
+      let(:event) { create(:event) }
+
+      before do
+        get :edit, id: event.id
+      end
+
+      it 'トップページにリダイレクトさせること' do
+        expect(response).to redirect_to(root_path)
+      end
     end
   end
 end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -233,6 +233,10 @@ RSpec.describe EventsController, type: :controller do
               expect(updated_event.start_time).to eq valid_request_params[:event][:start_time]
               expect(updated_event.end_time).to eq valid_request_params[:event][:end_time]
             end
+
+            it '更新後のイベント詳細ページにリダイレクトされれいること' do
+              expect(response).to redirect_to(event_path(event))
+            end
           end
         end
       end

--- a/spec/controllers/events_controller_spec.rb
+++ b/spec/controllers/events_controller_spec.rb
@@ -146,22 +146,32 @@ RSpec.describe EventsController, type: :controller do
       end
 
       context 'かつ指定したidのイベント情報が登録されている時' do
-        let(:event) { create(:event) }
+        context 'かつログインユーザーが作成したイベントである時' do
+          let(:event) { create(:event, owner: user) }
 
-        before do
-          get :edit, id: event.id
+          before do
+            get :edit, id: event.id
+          end
+
+          it '200が返されること' do
+            expect(response).to have_http_status(200)
+          end
+
+          it '指定したidのイベント情報が返されること' do
+            expect(assigns(:event).id).to eq event.id
+          end
+
+          it 'editテンプレートをrenderしていること' do
+            expect(response).to render_template :edit
+          end
         end
 
-        it '200が返されること' do
-          expect(response).to have_http_status(200)
-        end
+        context 'かつログインユーザーが作成したイベントでない時' do
+          let(:event) { create(:event) }
 
-        it '指定したidのイベント情報が返されること' do
-          expect(assigns(:event).id).to eq event.id
-        end
-
-        it 'editテンプレートをrenderしていること' do
-          expect(response).to render_template :edit
+          it 'ActiveRecord::RecordNotFoundがraiseされること' do
+            expect { get :edit, id: event.id }.to raise_error(ActiveRecord::RecordNotFound)
+          end
         end
       end
 

--- a/spec/models/event_spec.rb
+++ b/spec/models/event_spec.rb
@@ -41,4 +41,21 @@ RSpec.describe Event, type: :model do
   describe '#end_time' do
     it { should validate_presence_of(:end_time) }
   end
+
+  describe '#created_by?' do
+    let(:event) { create(:event) }
+    subject { event.created_by?(user) }
+
+    context '引数がnilの時' do
+      let(:user) { nil }
+
+      it { should be_falsey }
+    end
+
+    context '#owner_idと引数のuser#idが同じ時' do
+      let(:user) { double('user', id: event.id) }
+
+      it { should be_truthy }
+    end
+  end
 end

--- a/spec/views/events/show.html.erb_spec.rb
+++ b/spec/views/events/show.html.erb_spec.rb
@@ -5,6 +5,9 @@ RSpec.describe "events/show", type: :view do
     let(:event) { build(:event) }
 
     before do
+      def view.current_user; end
+      allow(view).to receive(:current_user).and_return(create(:user))
+
       assign(:event, event)
       render
     end

--- a/spec/views/events/show.html.erb_spec.rb
+++ b/spec/views/events/show.html.erb_spec.rb
@@ -2,18 +2,41 @@ require 'rails_helper'
 
 RSpec.describe "events/show", type: :view do
   context '指定したidのイベント情報が登録されていた時' do
-    let(:event) { build(:event) }
+    let(:user) { create(:user) }
 
     before do
       def view.current_user; end
-      allow(view).to receive(:current_user).and_return(create(:user))
-
-      assign(:event, event)
-      render
+      allow(view).to receive(:current_user).and_return(user)
     end
 
-    it 'イベント名が見出しとして表示されていること' do
-      expect(rendered).to match /#{event.name}/
+    context 'かつログインユーザーが作成したイベントである時' do
+      let(:event) { create(:event, owner: user) }
+
+      before do
+        assign(:event, event)
+        render
+      end
+
+      it 'イベント名が見出しとして表示されていること' do
+        expect(rendered).to match /#{event.name}/
+      end
+
+      it '「イベントを編集する」というリンクが表示されていること' do
+        expect(rendered).to have_link('イベントを編集する', edit_event_path(event))
+      end
+    end
+
+    context 'かつログインユーザーが作成したイベントでない時' do
+      let(:event) { build(:event) }
+
+      before do
+        assign(:event, event)
+        render
+      end
+
+      it '「イベントを編集する」というリンクは表示されていないこと' do
+        expect(rendered).not_to have_link('イベントを編集する')
+      end
     end
   end
 end


### PR DESCRIPTION
## 概要

p196 イベントの編集機能を作る
## やりたいこと
- [x] イベント詳細ページに「イベントを編集する」リンクを追加する
  - [x] イベントを作成したユーザーがアクセスした時だけ表示する
- [ ] 「イベントを編集する」をクリックすると、イベント編集フォームに遷移する
- [ ] イベント編集フォームで間違った入力をするとエラーメッセージが表示される
- [ ] イベント編集フォームで正しく入力をするとイベントが更新される
